### PR TITLE
feat(backtracking): add LC39 & LC40 Combination Sum

### DIFF
--- a/Python/backtracking/combinationSum2_40.py
+++ b/Python/backtracking/combinationSum2_40.py
@@ -1,0 +1,80 @@
+def combinationSum2(candidates, target):
+    """
+    Solves the Combination Sum II problem using backtracking.
+
+    Problem:
+    - Given a list of integers (candidates, may contain duplicates) and a target,
+      find all unique combinations where each number may be used **at most once**.
+    - The solution must not contain duplicate combinations.
+
+    Returns:
+        A list of lists, each inner list is one valid combination.
+
+    Time Complexity: O(2^N)
+        Because we explore all subsets.
+    Space Complexity: O(N)
+        Maximum recursion depth proportional to the number of candidates.
+    """
+
+    # Sort the candidates first to make it easier to skip duplicates
+    candidates.sort()
+
+    # Result list to store all valid combinations
+    result = []
+
+    # Helper function for backtracking
+    # Arguments:
+    # - start: index in candidates to start exploring
+    # - path: the current combination being constructed
+    # - total: sum of elements in the current path
+    def backtrack(start, path, total):
+        # Base case 1: total matches target -> valid combination
+        if total == target:
+            # Append a copy of current path
+            result.append(path[:])
+            return
+
+        # Base case 2: total exceeds target -> invalid path
+        if total > target:
+            return
+
+        # Iterate through candidates starting at index start
+        for i in range(start, len(candidates)):
+            candidate = candidates[i]
+
+            # Skip duplicates at the same recursion level
+            # i > start ensures only the first occurrence is used
+            if i > start and candidate == candidates[i - 1]:
+                continue
+
+            # Choose: add candidate to current combination
+            path.append(candidate)
+
+            # Explore: move to next index because each candidate can only be used once
+            backtrack(i + 1, path, total + candidate)
+
+            # Backtrack: remove last candidate to try next possibility
+            path.pop()
+
+    # Start backtracking from index 0, empty path, total 0
+    backtrack(0, [], 0)
+
+    return result
+
+
+# -------------------------------
+# Test Cases
+# -------------------------------
+if __name__ == "__main__":
+    print("Example 1: candidates = [10,1,2,7,6,1,5], target = 8")
+    solutions = combinationSum2([10,1,2,7,6,1,5], 8)
+    print("All valid combinations:")
+    for combo in solutions:
+        print(combo)
+    # Expected: [[1,1,6],[1,2,5],[1,7],[2,6]]
+
+    print("\nExample 2: candidates = [2,5,2,1,2], target = 5")
+    solutions = combinationSum2([2,5,2,1,2], 5)
+    for combo in solutions:
+        print(combo)
+    # Expected: [[1,2,2],[5]]

--- a/Python/backtracking/combinationSum_39.py
+++ b/Python/backtracking/combinationSum_39.py
@@ -1,0 +1,75 @@
+def combinationSum(candidates, target):
+    """
+    Solves the Combination Sum problem using backtracking.
+
+    Problem:
+    - Given a list of distinct integers (candidates) and a target sum,
+      find all unique combinations of candidates that sum to the target.
+    - Each number in candidates can be used **unlimited times** in the combination.
+    
+    Returns:
+        A list of lists, where each inner list is one valid combination.
+
+    Time Complexity: O(N^(T/M))
+        N = number of candidates, T = target, M = minimum candidate value
+        (exponential because we explore all combination possibilities)
+    Space Complexity: O(T/M)
+        (recursion depth proportional to target/min(candidates))
+    """
+
+    # This will store all valid combinations we find
+    result = []
+
+    # Define a helper function for backtracking
+    # Arguments:
+    # - current: the current combination being constructed
+    # - total: remaining sum needed to reach the target
+    # - idx: current index in candidates we're considering
+    def backtrack(current, total, idx):
+        # Base case 1: total is exactly zero -> valid combination
+        if total == 0:
+            # Add a copy of current combination to the result
+            result.append(list(current))
+            return
+
+        # Base case 2: total becomes negative -> invalid path
+        if total < 0:
+            return
+
+        # Iterate over candidates starting from current index
+        for i in range(idx, len(candidates)):
+            candidate = candidates[i]
+
+            # Choose: add candidate to current combination
+            current.append(candidate)
+
+            # Explore: recursively try next step with updated total
+            # i, not i+1, because we can reuse the same candidate multiple times
+            backtrack(current, total - candidate, i)
+
+            # Backtrack: remove last candidate to try next option
+            current.pop()
+
+    # Start the backtracking with empty combination, full target, starting at index 0
+    backtrack([], target, 0)
+
+    return result
+
+
+# -------------------------------
+# Test Cases
+# -------------------------------
+if __name__ == "__main__":
+    # Example 1
+    print("Example 1: candidates = [2,3,6,7], target = 7")
+    solutions = combinationSum([2,3,6,7], 7)
+    print("All valid combinations:")
+    for combo in solutions:
+        print(combo)
+    # Expected output: [[2,2,3], [7]]
+
+    print("\nExample 2: candidates = [2,3,5], target = 8")
+    solutions = combinationSum([2,3,5], 8)
+    for combo in solutions:
+        print(combo)
+    # Expected output: [[2,2,2,2], [2,3,3], [3,5]]


### PR DESCRIPTION
This PR adds two backtracking solutions:

1. combination_sum.py
   - Combination Sum I (LC39)
   - Candidates may be reused unlimited times.

2. combination_sum2.py
   - Combination Sum II (LC40)
   - Each candidate used at most once, duplicates handled.

Includes inline explanations and test cases under __main__.
