### PR TITLE
Prevent NullPointerException in FindMiddle

### DIFF
--- a/Java/linked_lists/FindMiddle.java
+++ b/Java/linked_lists/FindMiddle.java
@@ -9,6 +9,9 @@ class Node {
 
 public class FindMiddle {
     static int findMiddle(Node head) {
+        if (head == null) {
+            return -1; // Or throw an exception depending on requirements
+        }
         Node slow = head;
         Node fast = head;
         while (fast != null && fast.next != null) {


### PR DESCRIPTION
The `findMiddle` method was accessing `slow.data` without checking if the input `head` was null. If `head` is null, `slow` becomes null, leading to a `NullPointerException`. 

This PR adds a null check at the beginning of the method to handle empty lists gracefully by returning -1.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.